### PR TITLE
Move react-thanos to Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A curated list about React Hooks.
 - [React Spring demo](https://codesandbox.io/s/ppxnl191zx) - Demo of how react-spring could use React Hooks as a new API.
 - [React Hooks](https://codesandbox.io/s/yq5qowzrvz) - React Hooks useState() and useEffect().
 - [Hooks Todo App](https://codesandbox.io/s/9kwyzy0y4) - App made with React Hooks.
-- [react-thanos](https://github.com/codeshifu/react-thanos) - React hooks implementation of Google's Thanos easter egg
+- [react-thanos](https://github.com/codeshifu/react-thanos) - React hooks implementation of Google's Thanos easter egg.
 
 ## Extensions/Libraries
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A curated list about React Hooks.
 - [React Spring demo](https://codesandbox.io/s/ppxnl191zx) - Demo of how react-spring could use React Hooks as a new API.
 - [React Hooks](https://codesandbox.io/s/yq5qowzrvz) - React Hooks useState() and useEffect().
 - [Hooks Todo App](https://codesandbox.io/s/9kwyzy0y4) - App made with React Hooks.
+- [react-thanos](https://github.com/codeshifu/react-thanos) - React hooks implementation of Google's Thanos easter egg
 
 ## Extensions/Libraries
 
@@ -89,7 +90,6 @@ A curated list about React Hooks.
 - [react-hooks-screen-type](https://github.com/pankod/react-hooks-screen-type) - Determining screen size type for Bootstrap 4 grid.
 - [use-http](https://github.com/alex-cory/react-usefetch) - React hooks for making isomorphic HTTP requests.
 - [react-fetch-hook](https://github.com/ilyalesik/react-fetch-hook) - React hook for conveniently use Fetch API.
-- [react-thanos](https://github.com/codeshifu/react-thanos) - React hooks implementation of Google's Thanos easter egg
 
 ## License
 


### PR DESCRIPTION
Closes #8 

This is an alternative PR that just moves `react-thanos` to the Examples section, instead of completely removing it. The `react-thanos` source code is still useful as a reference for how to use hooks, even though the library itself is not implemented to be used _as_ a hook.