### PR TITLE
include react-hook-form in the library list

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated list about React Hooks.
 - [The Platform](https://github.com/palmerhq/the-platform) - Browser API's turned into React Hooks and Suspense-friendly React elements for common situations.
 - [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) - This plugin enforce rule of hooks to avoid common mistakes.
 - [react-hooks-lib](https://github.com/beizhedenglong/react-hooks-lib) - A set of reusable React Hooks.
+- [react-hook-form](https://github.com/bluebill1049/react-hook-form) - Performance, flexible and extensible forms with easy to use for validation.
 - [use-immer](https://github.com/mweststrate/use-immer) - A hook to use immer as a React hook to manipulate state.
 - [react-hanger](https://github.com/kitze/react-hanger) - A small collection of useful hooks for React 16.7.
 - [react-firebase-hooks](https://github.com/csfrequency/react-firebase-hooks) - A set of reusable React Hooks for Firebase.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ A curated list about React Hooks.
 - [The Platform](https://github.com/palmerhq/the-platform) - Browser API's turned into React Hooks and Suspense-friendly React elements for common situations.
 - [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) - This plugin enforce rule of hooks to avoid common mistakes.
 - [react-hooks-lib](https://github.com/beizhedenglong/react-hooks-lib) - A set of reusable React Hooks.
-- [react-hook-form](https://github.com/bluebill1049/react-hook-form) - Performance, flexible and extensible forms with easy to use for validation.
 - [use-immer](https://github.com/mweststrate/use-immer) - A hook to use immer as a React hook to manipulate state.
 - [react-hanger](https://github.com/kitze/react-hanger) - A small collection of useful hooks for React 16.7.
 - [react-firebase-hooks](https://github.com/csfrequency/react-firebase-hooks) - A set of reusable React Hooks for Firebase.
@@ -91,6 +90,7 @@ A curated list about React Hooks.
 - [react-hooks-screen-type](https://github.com/pankod/react-hooks-screen-type) - Determining screen size type for Bootstrap 4 grid.
 - [use-http](https://github.com/alex-cory/react-usefetch) - React hooks for making isomorphic HTTP requests.
 - [react-fetch-hook](https://github.com/ilyalesik/react-fetch-hook) - React hook for conveniently use Fetch API.
+- [react-hook-form](https://github.com/bluebill1049/react-hook-form) - Performance, flexible and extensible forms with easy to use for validation.
 
 ## License
 


### PR DESCRIPTION
Hi, 

wondering if possible to include `react-hook-form` in the readme?

github: https://github.com/bluebill1049/react-hook-form
docs: http://react-hook-form.now.sh

cheers
bill